### PR TITLE
Cast bools to ints and empty strings to null

### DIFF
--- a/tap_lightspeed/client.py
+++ b/tap_lightspeed/client.py
@@ -119,7 +119,7 @@ class LightspeedStream(RESTStream):
                 # Lightspeed API sometimes will return integer values as True or False.
                 # This tap casts True to 1, and will case False to None below
                 if field_type == "integer" and value is True:
-                    row[field] = 1
+                    row[field] = None
 
                 # Lightspeed sometimes returns nullish values as empty strings
                 if value == "" and field_type in ["integer", "number"]:

--- a/tap_lightspeed/client.py
+++ b/tap_lightspeed/client.py
@@ -117,9 +117,9 @@ class LightspeedStream(RESTStream):
                     row[field] = float(value) if value else None
                 
                 # Lightspeed API sometimes will return integer values as True or False.
-                # This tap casts to 1 and 0 accordingly
-                if isinstance(value, bool) and field_type == "integer" and value is True:
-                    row[field] = int(value) if value else None
+                # This tap casts True to 1, and will case False to None below
+                if field_type == "integer" and value is True:
+                    row[field] = 1
 
                 # Lightspeed sometimes returns nullish values as empty strings
                 if value == "" and field_type in ["integer", "number"]:

--- a/tap_lightspeed/client.py
+++ b/tap_lightspeed/client.py
@@ -117,8 +117,8 @@ class LightspeedStream(RESTStream):
                     row[field] = float(value) if value else None
                 
                 # Lightspeed API sometimes will return integer values as True or False.
-                # This tap casts True to 1, and will case False to None below
-                if field_type == "integer" and value is True:
+                # Absent any documentation on why, the tap converts them to None
+                if isinstance(value, bool) and field_type == "integer":
                     row[field] = None
 
                 # Lightspeed sometimes returns nullish values as empty strings


### PR DESCRIPTION
Lightspeed's API sometimes returns True/False for integer values and "" for nullable numerical values.

This PR casts bools and "" to null