### PR TITLE
feature/hgi-10597 | Coerce value field to string type

### DIFF
--- a/tap_lightspeed/streams.py
+++ b/tap_lightspeed/streams.py
@@ -261,11 +261,13 @@ class OrderMetafieldsStream(LightspeedStream):
     ).to_dict()
 
     def post_process(self, record, context):
-        # Coerce ``value`` to a string before the generic cleaning runs.
-        # ``clean_values`` nulls out any non-boolean field equal to ``False``,
-        # and ``0 == False`` in Python, so a numeric ``0`` would otherwise be
-        # turned into ``None`` (and then ``""``) instead of ``"0"``.
-        record["value"] = str(record["value"]) if record.get("value") is not None else ""
+        # ``value`` is a string field, but the API may return numbers or
+        # booleans. A boolean ``False`` (and ``None``) represents an absent
+        # value and should become ``""``. Everything else is stringified so
+        # that a numeric ``0`` is preserved as ``"0"`` rather than being
+        # nulled out by ``clean_values`` (where ``0 == False`` is ``True``).
+        value = record.get("value")
+        record["value"] = "" if value is None or value is False else str(value)
         return super().post_process(record, context)
 
 
@@ -499,11 +501,13 @@ class ProductsMetafieldsStream(LightspeedStream):
     ).to_dict()
     
     def post_process(self, record, context):
-        # Coerce ``value`` to a string before the generic cleaning runs.
-        # ``clean_values`` nulls out any non-boolean field equal to ``False``,
-        # and ``0 == False`` in Python, so a numeric ``0`` would otherwise be
-        # turned into ``None`` (and then ``""``) instead of ``"0"``.
-        record["value"] = str(record["value"]) if record.get("value") is not None else ""
+        # ``value`` is a string field, but the API may return numbers or
+        # booleans. A boolean ``False`` (and ``None``) represents an absent
+        # value and should become ``""``. Everything else is stringified so
+        # that a numeric ``0`` is preserved as ``"0"`` rather than being
+        # nulled out by ``clean_values`` (where ``0 == False`` is ``True``).
+        value = record.get("value")
+        record["value"] = "" if value is None or value is False else str(value)
         return super().post_process(record, context)
 
 class CategoriesStream(LightspeedStream):

--- a/tap_lightspeed/streams.py
+++ b/tap_lightspeed/streams.py
@@ -260,6 +260,13 @@ class OrderMetafieldsStream(LightspeedStream):
         th.Property("order_id", th.IntegerType),
     ).to_dict()
 
+    def post_process(self, record, context):
+        super().post_process(record, context)
+
+        """Ensure value is always a string."""
+        record["value"] = str(record["value"]) if record.get("value") is not None else ""
+        return record
+
 
 class ShipmentsLinesStream(LightspeedStream):
     """Define custom stream."""

--- a/tap_lightspeed/streams.py
+++ b/tap_lightspeed/streams.py
@@ -243,7 +243,21 @@ class OrderLinesStream(LightspeedStream):
     ).to_dict()
 
 
-class OrderMetafieldsStream(LightspeedStream):
+class MetafieldsStream(LightspeedStream):
+    """Base stream for metafields with shared value normalization."""
+
+    def post_process(self, record, context):
+        # ``value`` is a string field, but the API may return numbers or
+        # booleans. A boolean ``False`` (and ``None``) represents an absent
+        # value and should become ``""``. Everything else is stringified so
+        # that a numeric ``0`` is preserved as ``"0"`` rather than being
+        # nulled out by ``clean_values`` (where ``0 == False`` is ``True``).
+        value = record.get("value")
+        record["value"] = "" if value is None or value is False else str(value)
+        return super().post_process(record, context)
+
+
+class OrderMetafieldsStream(MetafieldsStream):
     """Define custom stream."""
 
     name = "order_metafields"
@@ -259,16 +273,6 @@ class OrderMetafieldsStream(LightspeedStream):
         th.Property("value", th.StringType),
         th.Property("order_id", th.IntegerType),
     ).to_dict()
-
-    def post_process(self, record, context):
-        # ``value`` is a string field, but the API may return numbers or
-        # booleans. A boolean ``False`` (and ``None``) represents an absent
-        # value and should become ``""``. Everything else is stringified so
-        # that a numeric ``0`` is preserved as ``"0"`` rather than being
-        # nulled out by ``clean_values`` (where ``0 == False`` is ``True``).
-        value = record.get("value")
-        record["value"] = "" if value is None or value is False else str(value)
-        return super().post_process(record, context)
 
 
 class ShipmentsLinesStream(LightspeedStream):
@@ -483,7 +487,7 @@ class ProductsImagesStream(LightspeedStream):
     ).to_dict()
 
 
-class ProductsMetafieldsStream(LightspeedStream):
+class ProductsMetafieldsStream(MetafieldsStream):
     """Define custom stream."""
 
     name = "products_metafields"
@@ -499,16 +503,7 @@ class ProductsMetafieldsStream(LightspeedStream):
         th.Property("value", th.StringType),
         th.Property("product_id", th.IntegerType),
     ).to_dict()
-    
-    def post_process(self, record, context):
-        # ``value`` is a string field, but the API may return numbers or
-        # booleans. A boolean ``False`` (and ``None``) represents an absent
-        # value and should become ``""``. Everything else is stringified so
-        # that a numeric ``0`` is preserved as ``"0"`` rather than being
-        # nulled out by ``clean_values`` (where ``0 == False`` is ``True``).
-        value = record.get("value")
-        record["value"] = "" if value is None or value is False else str(value)
-        return super().post_process(record, context)
+
 
 class CategoriesStream(LightspeedStream):
     """Define custom stream."""

--- a/tap_lightspeed/streams.py
+++ b/tap_lightspeed/streams.py
@@ -261,11 +261,12 @@ class OrderMetafieldsStream(LightspeedStream):
     ).to_dict()
 
     def post_process(self, record, context):
-        super().post_process(record, context)
-
-        """Ensure value is always a string."""
+        # Coerce ``value`` to a string before the generic cleaning runs.
+        # ``clean_values`` nulls out any non-boolean field equal to ``False``,
+        # and ``0 == False`` in Python, so a numeric ``0`` would otherwise be
+        # turned into ``None`` (and then ``""``) instead of ``"0"``.
         record["value"] = str(record["value"]) if record.get("value") is not None else ""
-        return record
+        return super().post_process(record, context)
 
 
 class ShipmentsLinesStream(LightspeedStream):
@@ -498,11 +499,12 @@ class ProductsMetafieldsStream(LightspeedStream):
     ).to_dict()
     
     def post_process(self, record, context):
-        super().post_process(record, context)
-
-        """Ensure value is always a string."""
+        # Coerce ``value`` to a string before the generic cleaning runs.
+        # ``clean_values`` nulls out any non-boolean field equal to ``False``,
+        # and ``0 == False`` in Python, so a numeric ``0`` would otherwise be
+        # turned into ``None`` (and then ``""``) instead of ``"0"``.
         record["value"] = str(record["value"]) if record.get("value") is not None else ""
-        return record
+        return super().post_process(record, context)
 
 class CategoriesStream(LightspeedStream):
     """Define custom stream."""


### PR DESCRIPTION
Sometimes we can get numbers in this field - coercing to strings as a metadata field to be consistent with schema 